### PR TITLE
[FIX] Make shop_ncf_config multicompany aware

### DIFF
--- a/ncf_manager/security/ncf_manager_security.xml
+++ b/ncf_manager/security/ncf_manager_security.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data>
+    <data noupdate="1">
+
+        <record id="shop_id_comp_rule" model="ir.rule">
+            <field name="name">Shop multi company rule</field>
+            <field name="model_id" ref="model_shop_ncf_config"/>
+            <field eval="True" name="global"/>
+            <field name="domain_force">['|',('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
+        </record>
 
     </data>
 </odoo>


### PR DESCRIPTION
Before this commit, the shop_id (Prefijo NCF) would show the prefix
from all companies, even if the user did not had access to other
companies. Now the user can only see the current company prefixes