### PR TITLE
Fix shop error

### DIFF
--- a/ncf_manager/models/shop.py
+++ b/ncf_manager/models/shop.py
@@ -111,7 +111,6 @@ class ShopJournalConfig(models.Model):
                 self.nd_sequence_id.write({"prefix": self.name+"03",
                                               "name": "Notas de debito {}".format(self.name)})
             else:
-		import ipdb;ipdb.set_trace()
                 self.setup_ncf(name=self.name,company_id=self.company_id.id, journal_id=self.journal_id.id,shop_id=self)
 
 


### PR DESCRIPTION
Eneldo, cuando se instala esta explotando porque no encontraba el journal_id, al verificar si no existia uno se le estaba asignando el 1 por defecto, y esto estaba rompiendo el modulo. Lo modificamos para buscar el diario de Facturas de Clientes por defecto, esto corrige dicho problema.