### PR TITLE
Correccion para un error de permisos

### DIFF
--- a/ncf_pos_premium/security/ir.model.access.csv
+++ b/ncf_pos_premium/security/ir.model.access.csv
@@ -3,3 +3,4 @@ access_pos_multi_session,access_pos_multi_session,model_pos_multi_session,point_
 access_pos_multi_session_order,access_pos_multi_session_order,model_pos_multi_session_order,point_of_sale.group_pos_user,1,1,1,1
 access_pos_config,access_pos_config,model_pos_config,point_of_sale.group_pos_user,1,1,1,1
 access_qty_pos_fraction,access_qty_pos_fraction,model_qty_pos_fraction,,1,1,1,1
+access_shop_ncf_config,access_shop_ncf_config,ncf_manager.model_shop_ncf_config,point_of_sale.group_pos_user,1,0,0,0


### PR DESCRIPTION
Habia un erorr en el POS premium que decia que los usuarios debian tener el permiso de "Accounting & Finance/Adviser" para el modelo shop.ncf.config al momento de validar las facturas